### PR TITLE
feat(observability): full k8s metrics coverage + dotdc dashboards + log-level detection

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -39,6 +39,15 @@
       ],
       "versioningTemplate": "regex:^(?<major>\\d+)$",
       "datasourceTemplate": "custom.grafana-dashboards"
+    },
+    {
+      "description": "Grafana plugins (grafana.com version)",
+      "customType": "regex",
+      "managerFilePatterns": ["/flux/.+\\.ya?ml$/"],
+      "matchStrings": [
+        "#\\s+renovate:\\s+depName=\"(?<depName>[^\"]+)\"\\s*\\n\\s+-\\s+name:\\s+\\S+\\s*\\n\\s+version:\\s+(?<currentValue>\\S+)"
+      ],
+      "datasourceTemplate": "custom.grafana-plugins"
     }
   ],
   "customDatasources": {
@@ -47,6 +56,13 @@
       "format": "json",
       "transformTemplates": [
         "{\"releases\":[{\"version\": $string(revision)}]}"
+      ]
+    },
+    "grafana-plugins": {
+      "defaultRegistryUrlTemplate": "https://grafana.com/api/plugins/{{packageName}}",
+      "format": "json",
+      "transformTemplates": [
+        "{\"releases\":[{\"version\": $string(version)}]}"
       ]
     }
   },

--- a/flux/observability/collect/cluster/app/apiserver.yml
+++ b/flux/observability/collect/cluster/app/apiserver.yml
@@ -1,0 +1,22 @@
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMServiceScrape
+metadata:
+  name: kube-apiserver
+  labels:
+    obs.nahsilabs/metrics: "true"
+spec:
+  namespaceSelector:
+    matchNames:
+      - default
+  selector:
+    matchLabels:
+      component: apiserver
+      provider: kubernetes
+  endpoints:
+    - port: https
+      scheme: https
+      interval: 30s
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig:
+        insecureSkipVerify: true
+        serverName: kubernetes

--- a/flux/observability/collect/cluster/app/coredns.yml
+++ b/flux/observability/collect/cluster/app/coredns.yml
@@ -1,0 +1,17 @@
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMServiceScrape
+metadata:
+  name: coredns
+  labels:
+    obs.nahsilabs/metrics: "true"
+spec:
+  namespaceSelector:
+    matchNames:
+      - kube-system
+  selector:
+    matchLabels:
+      k8s-app: kube-dns
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 30s

--- a/flux/observability/collect/cluster/app/kubelet.yml
+++ b/flux/observability/collect/cluster/app/kubelet.yml
@@ -1,0 +1,35 @@
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMNodeScrape
+metadata:
+  name: kubelet
+  labels:
+    obs.nahsilabs/metrics: "true"
+spec:
+  scheme: https
+  honorLabels: true
+  interval: 30s
+  tlsConfig:
+    insecureSkipVerify: true
+  bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+  relabelConfigs:
+    - action: labelmap
+      regex: __meta_kubernetes_node_label_(.+)
+---
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMNodeScrape
+metadata:
+  name: cadvisor
+  labels:
+    obs.nahsilabs/metrics: "true"
+spec:
+  scheme: https
+  path: /metrics/cadvisor
+  honorLabels: true
+  honorTimestamps: false
+  interval: 30s
+  tlsConfig:
+    insecureSkipVerify: true
+  bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+  relabelConfigs:
+    - action: labelmap
+      regex: __meta_kubernetes_node_label_(.+)

--- a/flux/observability/collect/cluster/app/kustomization.yml
+++ b/flux/observability/collect/cluster/app/kustomization.yml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - kubelet.yml
+  - apiserver.yml
+  - coredns.yml

--- a/flux/observability/collect/cluster/ks.yml
+++ b/flux/observability/collect/cluster/ks.yml
@@ -16,3 +16,23 @@ spec:
   interval: 1h
   retryInterval: 2m
   timeout: 5m
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: obs-cluster-dashboards
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: infra-grafana-operator
+    - name: obs-grafana
+  path: ./flux/observability/collect/cluster/obs
+  targetNamespace: obs-stack
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: infra
+    namespace: flux-system
+  interval: 1h
+  retryInterval: 2m
+  timeout: 5m

--- a/flux/observability/collect/cluster/ks.yml
+++ b/flux/observability/collect/cluster/ks.yml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: obs-cluster
+  namespace: flux-system
+spec:
+  path: ./flux/observability/collect/cluster/app
+  targetNamespace: obs-collect
+  prune: true
+  dependsOn:
+    - name: infra-vm-operator
+  sourceRef:
+    kind: GitRepository
+    name: infra
+    namespace: flux-system
+  interval: 1h
+  retryInterval: 2m
+  timeout: 5m

--- a/flux/observability/collect/cluster/kustomization.yml
+++ b/flux/observability/collect/cluster/kustomization.yml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ks.yml

--- a/flux/observability/collect/cluster/obs/dashboards.yml
+++ b/flux/observability/collect/cluster/obs/dashboards.yml
@@ -1,0 +1,77 @@
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: k8s-views-global
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "grafana"
+  grafanaCom:
+    # renovate: depName="Kubernetes / Views / Global"
+    id: 15757
+    revision: 43
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: k8s-views-namespaces
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "grafana"
+  grafanaCom:
+    # renovate: depName="Kubernetes / Views / Namespaces"
+    id: 15758
+    revision: 46
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: k8s-views-nodes
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "grafana"
+  grafanaCom:
+    # renovate: depName="Kubernetes / Views / Nodes"
+    id: 15759
+    revision: 40
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: k8s-views-pods
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "grafana"
+  grafanaCom:
+    # renovate: depName="Kubernetes / Views / Pods"
+    id: 15760
+    revision: 39
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: k8s-system-apiserver
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "grafana"
+  grafanaCom:
+    # renovate: depName="Kubernetes / System / API Server"
+    id: 15761
+    revision: 21
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: k8s-system-coredns
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "grafana"
+  grafanaCom:
+    # renovate: depName="Kubernetes / System / CoreDNS"
+    id: 15762
+    revision: 22

--- a/flux/observability/collect/cluster/obs/kustomization.yml
+++ b/flux/observability/collect/cluster/obs/kustomization.yml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - dashboards.yml

--- a/flux/observability/collect/kube-state-metrics/app/release.yml
+++ b/flux/observability/collect/kube-state-metrics/app/release.yml
@@ -18,5 +18,6 @@ spec:
     prometheus:
       monitor:
         enabled: true
+        honorLabels: true
         additionalLabels:
           obs.nahsilabs/metrics: "true"

--- a/flux/observability/collect/kube-state-metrics/app/release.yml
+++ b/flux/observability/collect/kube-state-metrics/app/release.yml
@@ -19,4 +19,4 @@ spec:
       monitor:
         enabled: true
         additionalLabels:
-          scrape: "true"
+          obs.nahsilabs/metrics: "true"

--- a/flux/observability/collect/kustomization.yml
+++ b/flux/observability/collect/kustomization.yml
@@ -6,3 +6,4 @@ resources:
   - vlagent
   - node-exporter
   - kube-state-metrics
+  - cluster

--- a/flux/observability/collect/vmagent/app/vmagent.yml
+++ b/flux/observability/collect/vmagent/app/vmagent.yml
@@ -8,6 +8,9 @@ spec:
     matchLabels:
       obs.nahsilabs/metrics: "true"
   serviceScrapeNamespaceSelector: {}
+  nodeScrapeSelector:
+    matchLabels:
+      obs.nahsilabs/metrics: "true"
   replicaCount: 1
   scrapeInterval: 30s
   externalLabels:

--- a/flux/observability/server/grafana/app/datasource.yml
+++ b/flux/observability/server/grafana/app/datasource.yml
@@ -57,6 +57,26 @@ spec:
         - { field: _msg, operator: regex, value: "level=warn", level: warning, enabled: true }
         - { field: _msg, operator: regex, value: "level=info", level: info, enabled: true }
         - { field: _msg, operator: regex, value: "level=debug", level: debug, enabled: true }
+        # zap/VictoriaMetrics tab-delimited console (`<ts>\tinfo\t<logger>`) — every
+        # Go controller-runtime operator (cert-manager, external-secrets, cnpg, vm,
+        # mariadb…) plus vmagent. Level is a bare tab-wrapped word, no level= key.
+        - { field: _msg, operator: regex, value: "\\t(fatal|panic|dpanic)\\t", level: critical, enabled: true }
+        - { field: _msg, operator: regex, value: "\\terror\\t", level: error, enabled: true }
+        - { field: _msg, operator: regex, value: "\\twarn\\t", level: warning, enabled: true }
+        - { field: _msg, operator: regex, value: "\\tinfo\\t", level: info, enabled: true }
+        - { field: _msg, operator: regex, value: "\\tdebug\\t", level: debug, enabled: true }
+        # servarr bracket prefix (`[Info] logger: msg`) — sonarr/radarr/prowlarr
+        - { field: _msg, operator: regex, value: "^\\[Fatal\\]", level: critical, enabled: true }
+        - { field: _msg, operator: regex, value: "^\\[Error\\]", level: error, enabled: true }
+        - { field: _msg, operator: regex, value: "^\\[Warn\\]", level: warning, enabled: true }
+        - { field: _msg, operator: regex, value: "^\\[Info\\]", level: info, enabled: true }
+        - { field: _msg, operator: regex, value: "^\\[(Debug|Trace)\\]", level: debug, enabled: true }
+        # synapse dash-delimited (`<ts> - logger - 111 - INFO - msg`) — matrix
+        - { field: _msg, operator: regex, value: " - (CRITICAL|FATAL) - ", level: critical, enabled: true }
+        - { field: _msg, operator: regex, value: " - ERROR - ", level: error, enabled: true }
+        - { field: _msg, operator: regex, value: " - WARNING - ", level: warning, enabled: true }
+        - { field: _msg, operator: regex, value: " - INFO - ", level: info, enabled: true }
+        - { field: _msg, operator: regex, value: " - DEBUG - ", level: debug, enabled: true }
         # envoy access logs have no level — derive from HTTP status (last, so real levels win)
         - { field: status, operator: regex, value: "^5[0-9][0-9]$", level: error, enabled: true }
         - { field: status, operator: regex, value: "^4[0-9][0-9]$", level: warning, enabled: true }

--- a/flux/observability/server/grafana/app/datasource.yml
+++ b/flux/observability/server/grafana/app/datasource.yml
@@ -62,5 +62,6 @@ spec:
         - { field: status, operator: regex, value: "^4[0-9][0-9]$", level: warning, enabled: true }
         - { field: status, operator: regex, value: "^[123][0-9][0-9]$", level: info, enabled: true }
   plugins:
+    # renovate: depName="victoriametrics-logs-datasource"
     - name: victoriametrics-logs-datasource
-      version: 0.27.1
+      version: 0.28.0


### PR DESCRIPTION
Rounds out the observability stack: scrape the metrics we were blind to, ship proven k8s dashboards, and make Grafana detect log levels for the formats in this cluster.

## Metrics coverage
- Scrape **kubelet, cadvisor, apiserver, coredns** (were missing — went from 2 jobs to 7). `container_*` and apiserver/dns metrics now flow.
- Fix **kube-state-metrics** gate label (`scrape:true` → `obs.nahsilabs/metrics:"true"`) so vmagent actually picks it up, and add `honorLabels` so `kube_pod_info` keeps the real `namespace`/`pod` instead of `exported_*`.
- `vmagent` gets a `nodeScrapeSelector` so the new VMNodeScrapes are selected.

## Dashboards
- Add the **dotdc kubernetes-dashboards** set (global/namespaces/nodes/pods views + apiserver/coredns system), renovate-tracked by grafana.com revision.

## Logs
- Bump victorialogs datasource plugin to **0.28.0**, renovate-track grafana plugins.
- Detect log level for the three non-logfmt `_msg` formats in the cluster so they stop rendering grey "unknown":
  - **zap/VM tab-delimited** (`<ts>⇥info⇥…`) — every Go controller-runtime operator + vmagent
  - **servarr bracket** (`[Info] …`) — arr
  - **synapse dash** (`<ts> - logger - 111 - INFO - …`) — matrix
- Verified live: matrix went from 100% unknown → info/warning detected (residual ~6% is plain-postgres checkpoint noise with no severity token).