### PR TITLE
feat: Migrate to csi driver nfs

### DIFF
--- a/flux/apps/arr/lidarr/app/volumes/nfs-music.yml
+++ b/flux/apps/arr/lidarr/app/volumes/nfs-music.yml
@@ -2,21 +2,30 @@
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: lidarr-music
+  name: nfs-lidarr-music
+  annotations:
+    pv.kubernetes.io/provisioned-by: nfs.csi.k8s.io
 spec:
   capacity:
     storage: 1Gi
   accessModes:
     - ReadWriteMany
   persistentVolumeReclaimPolicy: Retain
-  storageClassName: nfs-lidarr-music
+  storageClassName: ""
   mountOptions:
+    - nfsvers=4.1
     - nconnect=8
-    - hard
     - noatime
-  nfs:
-    server: nfs.lan
-    path: /mnt/storage/media/music
+    - soft
+    - softerr
+    - timeo=50
+    - retrans=3
+  csi:
+    driver: nfs.csi.k8s.io
+    volumeHandle: nfs.lan#mnt/storage/media/music#lidarr
+    volumeAttributes:
+      server: nfs.lan
+      share: /mnt/storage/media/music
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -25,8 +34,8 @@ metadata:
 spec:
   accessModes:
     - ReadWriteMany
-  storageClassName: nfs-lidarr-music
-  volumeName: lidarr-music
+  storageClassName: ""
+  volumeName: nfs-lidarr-music
   resources:
     requests:
       storage: 1Gi

--- a/flux/apps/arr/radarr/app/volumes.yml
+++ b/flux/apps/arr/radarr/app/volumes.yml
@@ -15,21 +15,30 @@ spec:
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: radarr-video
+  name: nfs-radarr-video
+  annotations:
+    pv.kubernetes.io/provisioned-by: nfs.csi.k8s.io
 spec:
   capacity:
-    storage: 1Gi # doesn't matter
+    storage: 1Gi
   accessModes:
     - ReadWriteMany
   persistentVolumeReclaimPolicy: Retain
-  storageClassName: nfs-radarr-video
-  mountOptions: 
-    - "nconnect=8"
-    - "hard" 
-    - "noatime"
-  nfs:
-    server: nfs.lan
-    path: /mnt/storage/media/video
+  storageClassName: ""
+  mountOptions:
+    - nfsvers=4.1
+    - nconnect=8
+    - noatime
+    - soft
+    - softerr
+    - timeo=50
+    - retrans=3
+  csi:
+    driver: nfs.csi.k8s.io
+    volumeHandle: nfs.lan#mnt/storage/media/video#radarr
+    volumeAttributes:
+      server: nfs.lan
+      share: /mnt/storage/media/video
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -38,8 +47,8 @@ metadata:
 spec:
   accessModes:
     - ReadWriteMany
-  storageClassName: nfs-radarr-video
-  volumeName: radarr-video
+  storageClassName: ""
+  volumeName: nfs-radarr-video
   resources:
     requests:
       storage: 1Gi

--- a/flux/apps/arr/sonarr/app/volumes.yml
+++ b/flux/apps/arr/sonarr/app/volumes.yml
@@ -15,21 +15,30 @@ spec:
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: sonarr-video
+  name: nfs-sonarr-video
+  annotations:
+    pv.kubernetes.io/provisioned-by: nfs.csi.k8s.io
 spec:
   capacity:
-    storage: 1Gi # doesn't matter
+    storage: 1Gi
   accessModes:
     - ReadWriteMany
   persistentVolumeReclaimPolicy: Retain
-  storageClassName: nfs-sonarr-video
-  mountOptions: 
-    - "nconnect=8"
-    - "hard" 
-    - "noatime"
-  nfs:
-    server: nfs.lan
-    path: /mnt/storage/media/video
+  storageClassName: ""
+  mountOptions:
+    - nfsvers=4.1
+    - nconnect=8
+    - noatime
+    - soft
+    - softerr
+    - timeo=50
+    - retrans=3
+  csi:
+    driver: nfs.csi.k8s.io
+    volumeHandle: nfs.lan#mnt/storage/media/video#sonarr
+    volumeAttributes:
+      server: nfs.lan
+      share: /mnt/storage/media/video
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -38,8 +47,8 @@ metadata:
 spec:
   accessModes:
     - ReadWriteMany
-  storageClassName: nfs-sonarr-video
-  volumeName: sonarr-video
+  storageClassName: ""
+  volumeName: nfs-sonarr-video
   resources:
     requests:
       storage: 1Gi

--- a/flux/apps/arr/soularr/app/volumes/nfs-downloads.yml
+++ b/flux/apps/arr/soularr/app/volumes/nfs-downloads.yml
@@ -2,21 +2,30 @@
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: soularr-downloads
+  name: nfs-soularr-downloads
+  annotations:
+    pv.kubernetes.io/provisioned-by: nfs.csi.k8s.io
 spec:
   capacity:
     storage: 1Gi
   accessModes:
     - ReadWriteMany
   persistentVolumeReclaimPolicy: Retain
-  storageClassName: nfs-soularr-downloads
+  storageClassName: ""
   mountOptions:
+    - nfsvers=4.1
     - nconnect=8
-    - hard
     - noatime
-  nfs:
-    server: nfs.lan
-    path: /mnt/storage/media/music/slskd
+    - soft
+    - softerr
+    - timeo=50
+    - retrans=3
+  csi:
+    driver: nfs.csi.k8s.io
+    volumeHandle: nfs.lan#mnt/storage/media/music/slskd#soularr
+    volumeAttributes:
+      server: nfs.lan
+      share: /mnt/storage/media/music/slskd
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -25,8 +34,8 @@ metadata:
 spec:
   accessModes:
     - ReadWriteMany
-  storageClassName: nfs-soularr-downloads
-  volumeName: soularr-downloads
+  storageClassName: ""
+  volumeName: nfs-soularr-downloads
   resources:
     requests:
       storage: 1Gi

--- a/flux/apps/downloads/qbittorrent/app/release.yml
+++ b/flux/apps/downloads/qbittorrent/app/release.yml
@@ -83,9 +83,7 @@ spec:
         globalMounts:
           - path: /mnt/downloads
       video:
-        type: nfs
-        server: nfs.lan
-        path: /mnt/storage/media/video
+        existingClaim: qbittorrent-video
         globalMounts:
           - path: /mnt/video
 

--- a/flux/apps/downloads/qbittorrent/app/volumes/kustomization.yml
+++ b/flux/apps/downloads/qbittorrent/app/volumes/kustomization.yml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
   - ceph.yml
   - nfs-downloads.yml
+  - nfs-video.yml

--- a/flux/apps/downloads/qbittorrent/app/volumes/nfs-downloads.yml
+++ b/flux/apps/downloads/qbittorrent/app/volumes/nfs-downloads.yml
@@ -2,21 +2,30 @@
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: qbittorrent-downloads
+  name: nfs-qbittorrent-downloads
+  annotations:
+    pv.kubernetes.io/provisioned-by: nfs.csi.k8s.io
 spec:
   capacity:
     storage: 1Gi
   accessModes:
     - ReadWriteMany
   persistentVolumeReclaimPolicy: Retain
-  storageClassName: nfs-qbittorrent-downloads
+  storageClassName: ""
   mountOptions:
+    - nfsvers=4.1
     - nconnect=8
-    - hard
     - noatime
-  nfs:
-    server: nfs.lan
-    path: /mnt/storage/downloads
+    - soft
+    - softerr
+    - timeo=50
+    - retrans=3
+  csi:
+    driver: nfs.csi.k8s.io
+    volumeHandle: nfs.lan#mnt/storage/downloads#qbittorrent
+    volumeAttributes:
+      server: nfs.lan
+      share: /mnt/storage/downloads
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -25,8 +34,8 @@ metadata:
 spec:
   accessModes:
     - ReadWriteMany
-  storageClassName: nfs-qbittorrent-downloads
-  volumeName: qbittorrent-downloads
+  storageClassName: ""
+  volumeName: nfs-qbittorrent-downloads
   resources:
     requests:
       storage: 1Gi

--- a/flux/apps/downloads/qbittorrent/app/volumes/nfs-video.yml
+++ b/flux/apps/downloads/qbittorrent/app/volumes/nfs-video.yml
@@ -1,32 +1,8 @@
 ---
 apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: immich-ml-cache
-spec:
-  accessModes:
-    - ReadWriteOnce
-  storageClassName: ceph-rbd-delete
-  resources:
-    requests:
-      storage: 10Gi
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: immich-valkey
-spec:
-  accessModes:
-    - ReadWriteOnce
-  storageClassName: ceph-rbd-delete
-  resources:
-    requests:
-      storage: 2Gi
----
-apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: nfs-immich-photos
+  name: nfs-qbittorrent-video
   annotations:
     pv.kubernetes.io/provisioned-by: nfs.csi.k8s.io
 spec:
@@ -46,20 +22,20 @@ spec:
     - retrans=3
   csi:
     driver: nfs.csi.k8s.io
-    volumeHandle: nfs.lan#mnt/storage/media/photos#immich
+    volumeHandle: nfs.lan#mnt/storage/media/video#qbittorrent
     volumeAttributes:
       server: nfs.lan
-      share: /mnt/storage/media/photos
+      share: /mnt/storage/media/video
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: immich-photos
+  name: qbittorrent-video
 spec:
   accessModes:
     - ReadWriteMany
   storageClassName: ""
-  volumeName: nfs-immich-photos
+  volumeName: nfs-qbittorrent-video
   resources:
     requests:
       storage: 1Gi

--- a/flux/apps/downloads/slskd/app/release.yml
+++ b/flux/apps/downloads/slskd/app/release.yml
@@ -85,9 +85,7 @@ spec:
         globalMounts:
           - path: /downloads
       music:
-        type: nfs
-        server: nfs.lan
-        path: /mnt/storage/media/music/library
+        existingClaim: slskd-music
         globalMounts:
           - path: /music
             readOnly: true

--- a/flux/apps/downloads/slskd/app/volumes/kustomization.yml
+++ b/flux/apps/downloads/slskd/app/volumes/kustomization.yml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
   - ceph.yml
   - nfs-downloads.yml
+  - nfs-music.yml

--- a/flux/apps/downloads/slskd/app/volumes/nfs-downloads.yml
+++ b/flux/apps/downloads/slskd/app/volumes/nfs-downloads.yml
@@ -2,21 +2,30 @@
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: slskd-downloads
+  name: nfs-slskd-downloads
+  annotations:
+    pv.kubernetes.io/provisioned-by: nfs.csi.k8s.io
 spec:
   capacity:
     storage: 1Gi
   accessModes:
     - ReadWriteMany
   persistentVolumeReclaimPolicy: Retain
-  storageClassName: nfs-slskd-downloads
+  storageClassName: ""
   mountOptions:
+    - nfsvers=4.1
     - nconnect=8
-    - hard
     - noatime
-  nfs:
-    server: nfs.lan
-    path: /mnt/storage/media/music/slskd
+    - soft
+    - softerr
+    - timeo=50
+    - retrans=3
+  csi:
+    driver: nfs.csi.k8s.io
+    volumeHandle: nfs.lan#mnt/storage/media/music/slskd#slskd
+    volumeAttributes:
+      server: nfs.lan
+      share: /mnt/storage/media/music/slskd
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -25,8 +34,8 @@ metadata:
 spec:
   accessModes:
     - ReadWriteMany
-  storageClassName: nfs-slskd-downloads
-  volumeName: slskd-downloads
+  storageClassName: ""
+  volumeName: nfs-slskd-downloads
   resources:
     requests:
       storage: 1Gi

--- a/flux/apps/downloads/slskd/app/volumes/nfs-music.yml
+++ b/flux/apps/downloads/slskd/app/volumes/nfs-music.yml
@@ -1,32 +1,8 @@
 ---
 apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: immich-ml-cache
-spec:
-  accessModes:
-    - ReadWriteOnce
-  storageClassName: ceph-rbd-delete
-  resources:
-    requests:
-      storage: 10Gi
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: immich-valkey
-spec:
-  accessModes:
-    - ReadWriteOnce
-  storageClassName: ceph-rbd-delete
-  resources:
-    requests:
-      storage: 2Gi
----
-apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: nfs-immich-photos
+  name: nfs-slskd-music
   annotations:
     pv.kubernetes.io/provisioned-by: nfs.csi.k8s.io
 spec:
@@ -46,20 +22,20 @@ spec:
     - retrans=3
   csi:
     driver: nfs.csi.k8s.io
-    volumeHandle: nfs.lan#mnt/storage/media/photos#immich
+    volumeHandle: nfs.lan#mnt/storage/media/music/library#slskd
     volumeAttributes:
       server: nfs.lan
-      share: /mnt/storage/media/photos
+      share: /mnt/storage/media/music/library
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: immich-photos
+  name: slskd-music
 spec:
   accessModes:
     - ReadWriteMany
   storageClassName: ""
-  volumeName: nfs-immich-photos
+  volumeName: nfs-slskd-music
   resources:
     requests:
       storage: 1Gi

--- a/flux/apps/grimmory/app/volumes.yml
+++ b/flux/apps/grimmory/app/volumes.yml
@@ -1,21 +1,31 @@
+---
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: grimmory-books
+  name: nfs-grimmory-books
+  annotations:
+    pv.kubernetes.io/provisioned-by: nfs.csi.k8s.io
 spec:
   capacity:
     storage: 1Gi
   accessModes:
     - ReadWriteMany
   persistentVolumeReclaimPolicy: Retain
-  storageClassName: nfs-grimmory-books
+  storageClassName: ""
   mountOptions:
-    - "nconnect=8"
-    - "hard"
-    - "noatime"
-  nfs:
-    server: nfs.lan
-    path: /mnt/storage/media/books
+    - nfsvers=4.1
+    - nconnect=8
+    - noatime
+    - soft
+    - softerr
+    - timeo=50
+    - retrans=3
+  csi:
+    driver: nfs.csi.k8s.io
+    volumeHandle: nfs.lan#mnt/storage/media/books#grimmory
+    volumeAttributes:
+      server: nfs.lan
+      share: /mnt/storage/media/books
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -24,8 +34,8 @@ metadata:
 spec:
   accessModes:
     - ReadWriteMany
-  storageClassName: nfs-grimmory-books
-  volumeName: grimmory-books
+  storageClassName: ""
+  volumeName: nfs-grimmory-books
   resources:
     requests:
       storage: 1Gi

--- a/flux/apps/jellyfin/app/release.yml
+++ b/flux/apps/jellyfin/app/release.yml
@@ -78,16 +78,12 @@ spec:
           - path: /config
 
       video:
-        type: nfs
-        server: nfs.lan
-        path: /mnt/storage/media/video
+        existingClaim: jellyfin-video
         globalMounts:
           - path: /data/video
 
       music:
-        type: nfs
-        server: nfs.lan
-        path: /mnt/storage/media/music/library
+        existingClaim: jellyfin-music
         globalMounts:
           - path: /data/music
 

--- a/flux/apps/jellyfin/app/volumes/kustomization.yml
+++ b/flux/apps/jellyfin/app/volumes/kustomization.yml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ceph.yml
+  - nfs.yml

--- a/flux/apps/jellyfin/app/volumes/nfs.yml
+++ b/flux/apps/jellyfin/app/volumes/nfs.yml
@@ -1,21 +1,8 @@
 ---
 apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: audiobookshelf-config
-spec:
-  accessModes:
-    - ReadWriteOnce
-  storageClassName: ceph-rbd-retain
-  volumeName: pvc-8d615b53-0933-476d-b088-27c3680423ef
-  resources:
-    requests:
-      storage: 1Gi
----
-apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: nfs-audiobookshelf-audiobooks
+  name: nfs-jellyfin-video
   annotations:
     pv.kubernetes.io/provisioned-by: nfs.csi.k8s.io
 spec:
@@ -35,20 +22,20 @@ spec:
     - retrans=3
   csi:
     driver: nfs.csi.k8s.io
-    volumeHandle: nfs.lan#mnt/storage/media/audiobooks#audiobookshelf
+    volumeHandle: nfs.lan#mnt/storage/media/video#jellyfin
     volumeAttributes:
       server: nfs.lan
-      share: /mnt/storage/media/audiobooks
+      share: /mnt/storage/media/video
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: audiobookshelf-audiobooks
+  name: jellyfin-video
 spec:
   accessModes:
     - ReadWriteMany
   storageClassName: ""
-  volumeName: nfs-audiobookshelf-audiobooks
+  volumeName: nfs-jellyfin-video
   resources:
     requests:
       storage: 1Gi
@@ -56,7 +43,7 @@ spec:
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: nfs-audiobookshelf-podcasts
+  name: nfs-jellyfin-music
   annotations:
     pv.kubernetes.io/provisioned-by: nfs.csi.k8s.io
 spec:
@@ -76,20 +63,20 @@ spec:
     - retrans=3
   csi:
     driver: nfs.csi.k8s.io
-    volumeHandle: nfs.lan#mnt/storage/media/podcasts#audiobookshelf
+    volumeHandle: nfs.lan#mnt/storage/media/music/library#jellyfin
     volumeAttributes:
       server: nfs.lan
-      share: /mnt/storage/media/podcasts
+      share: /mnt/storage/media/music/library
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: audiobookshelf-podcasts
+  name: jellyfin-music
 spec:
   accessModes:
     - ReadWriteMany
   storageClassName: ""
-  volumeName: nfs-audiobookshelf-podcasts
+  volumeName: nfs-jellyfin-music
   resources:
     requests:
       storage: 1Gi

--- a/flux/apps/navidrome/app/volumes/nfs-music.yml
+++ b/flux/apps/navidrome/app/volumes/nfs-music.yml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: PersistentVolume
 metadata:
   name: navidrome-music
+  annotations:
+    pv.kubernetes.io/provisioned-by: nfs.csi.k8s.io
 spec:
   capacity:
     storage: 1Gi
@@ -11,12 +13,19 @@ spec:
   persistentVolumeReclaimPolicy: Retain
   storageClassName: nfs-navidrome-music
   mountOptions:
+    - nfsvers=4.1
     - nconnect=8
-    - hard
     - noatime
-  nfs:
-    server: nfs.lan
-    path: /mnt/storage/media/music/library
+    - soft
+    - softerr
+    - timeo=50
+    - retrans=3
+  csi:
+    driver: nfs.csi.k8s.io
+    volumeHandle: nfs.lan#mnt/storage/media/music/library#navidrome
+    volumeAttributes:
+      server: nfs.lan
+      share: /mnt/storage/media/music/library
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/flux/apps/navidrome/app/volumes/nfs-music.yml
+++ b/flux/apps/navidrome/app/volumes/nfs-music.yml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: navidrome-music
+  name: nfs-navidrome-music
   annotations:
     pv.kubernetes.io/provisioned-by: nfs.csi.k8s.io
 spec:
@@ -11,7 +11,7 @@ spec:
   accessModes:
     - ReadWriteMany
   persistentVolumeReclaimPolicy: Retain
-  storageClassName: nfs-navidrome-music
+  storageClassName: ""
   mountOptions:
     - nfsvers=4.1
     - nconnect=8
@@ -34,8 +34,8 @@ metadata:
 spec:
   accessModes:
     - ReadWriteMany
-  storageClassName: nfs-navidrome-music
-  volumeName: navidrome-music
+  storageClassName: ""
+  volumeName: nfs-navidrome-music
   resources:
     requests:
       storage: 1Gi

--- a/flux/infrastructure/controllers/csi-driver-nfs/app/kustomization.yml
+++ b/flux/infrastructure/controllers/csi-driver-nfs/app/kustomization.yml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - release.yml

--- a/flux/infrastructure/controllers/csi-driver-nfs/app/release.yml
+++ b/flux/infrastructure/controllers/csi-driver-nfs/app/release.yml
@@ -23,3 +23,5 @@ spec:
       replicas: 2
     externalSnapshotter:
       enabled: false
+    feature:
+      enableFSGroupPolicy: false

--- a/flux/infrastructure/controllers/csi-driver-nfs/app/release.yml
+++ b/flux/infrastructure/controllers/csi-driver-nfs/app/release.yml
@@ -1,0 +1,25 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: csi-driver-nfs
+spec:
+  interval: 1h
+  chart:
+    spec:
+      chart: csi-driver-nfs
+      version: 4.13.2
+      sourceRef:
+        kind: HelmRepository
+        name: csi-driver-nfs
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  values:
+    controller:
+      replicas: 2
+    externalSnapshotter:
+      enabled: false

--- a/flux/infrastructure/controllers/csi-driver-nfs/ks.yml
+++ b/flux/infrastructure/controllers/csi-driver-nfs/ks.yml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: infra-csi-driver-nfs
+  namespace: flux-system
+spec:
+  interval: 1h
+  timeout: 15m
+  retryInterval: 2m
+  prune: true
+  wait: true
+  targetNamespace: kube-system
+  sourceRef:
+    kind: GitRepository
+    name: infra
+    namespace: flux-system
+  path: ./flux/infrastructure/controllers/csi-driver-nfs/app

--- a/flux/infrastructure/controllers/csi-driver-nfs/kustomization.yml
+++ b/flux/infrastructure/controllers/csi-driver-nfs/kustomization.yml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ks.yml

--- a/flux/infrastructure/controllers/kustomization.yml
+++ b/flux/infrastructure/controllers/kustomization.yml
@@ -7,6 +7,7 @@ resources:
   - metrics-server
   - kubelet-csr-approver
   - ceph-csi-rbd
+  - csi-driver-nfs
   - envoy-gateway
   - agenticgateway
   - cloudnative-pg

--- a/flux/infrastructure/controllers/node-feature-discovery/app/release.yml
+++ b/flux/infrastructure/controllers/node-feature-discovery/app/release.yml
@@ -27,12 +27,14 @@ spec:
       startupProbe:
         failureThreshold: 60
         timeoutSeconds: 5
+      livenessProbe:
+        timeoutSeconds: 5
       resources:
         requests:
           cpu: 21m
-          memory: 51Mi
+          memory: 128Mi
         limits:
-          memory: 51Mi
+          memory: 128Mi
     worker:
       config:
         core:

--- a/flux/observability/collect/vmagent/app/vmagent.yml
+++ b/flux/observability/collect/vmagent/app/vmagent.yml
@@ -20,6 +20,6 @@ spec:
   resources:
     requests:
       cpu: 100m
-      memory: 200Mi
-    limits:
       memory: 256Mi
+    limits:
+      memory: 512Mi

--- a/flux/repositories/helm/csi-driver-nfs.yml
+++ b/flux/repositories/helm/csi-driver-nfs.yml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: csi-driver-nfs
+  namespace: flux-system
+spec:
+  interval: 5m
+  url: https://raw.githubusercontent.com/kubernetes-csi/csi-driver-nfs/master/charts

--- a/flux/repositories/helm/kustomization.yml
+++ b/flux/repositories/helm/kustomization.yml
@@ -5,6 +5,7 @@ resources:
   - kubernetest-sigs-nfd.yml
   - postfinance.yml
   - ceph-csi.yml
+  - csi-driver-nfs.yml
   - bjw-s.yml
   - external-dns.yml
   - cert-manager.yml


### PR DESCRIPTION
- **feat(csi-driver-nfs): add NFS CSI driver, pilot navidrome on soft mounts**
- **refactor(navidrome): rename music PV to nfs-navidrome-music, drop dummy storageClass**
- **fix(vmagent): raise memory limit to 512Mi to stop OOMKill crashloop**
- **refactor(nfs): migrate all NFS volumes to csi-driver-nfs with soft mounts**
- **fix(csi-driver-nfs): disable fsGroupPolicy to stop recursive chown on NFS**
- **fix(node-feature-discovery): raise master memory to 128Mi, loosen liveness probe**
